### PR TITLE
Update jenkins-bootstrap-shared submodule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply from: "${bootstrapHome}/shared.gradle"
 //version should be the jenkins.war version appended by .1 and increments .1
 //every time there's non-jenkins.war version changes to the package.
 //if upgrading jenkins.war version then it should be reset to .1.
-version = '2.7.4.2'
+version = '2.7.4.3'
 description = "Built from ${tokens['PACKAGENAME']} @ ${tokens['COMMIT']}"
 
 //Jenkins war and plugin versions


### PR DESCRIPTION
This brings in the latest fixes from [jenkins-bootstrap-shared][1].  After this change is merged build.gimp.org will be upgraded to use this package.

[1]: https://github.com/samrocketman/jenkins-bootstrap-shared